### PR TITLE
Notify correct timeout in message

### DIFF
--- a/pkg/nanny/nanny.go
+++ b/pkg/nanny/nanny.go
@@ -101,10 +101,8 @@ func (n *Nanny) handle(s validSignal) error {
 		n.lock.Unlock()
 	} else {
 		// No timer is registered for this program, create it.
-		newTimer := &nannyTimer{s, time.NewTimer(s.NextSignal)}
-
-		go func() {
-			<-newTimer.timer.C
+		newTimer := &nannyTimer{signal: s}
+		newTimer.timer = time.AfterFunc(newTimer.signal.NextSignal, func() {
 			err := newTimer.signal.Notifier.Notify(n.msg(newTimer.signal))
 			if err != nil {
 				// Add context to the error message and call ErrorFunc.
@@ -121,8 +119,7 @@ func (n *Nanny) handle(s validSignal) error {
 				signal := Signal(newTimer.signal)
 				newTimer.signal.CallbackFunc(&signal)
 			}
-		}()
-
+		})
 		n.SetTimer(s.Name, newTimer)
 	}
 

--- a/pkg/nanny/nanny.go
+++ b/pkg/nanny/nanny.go
@@ -115,7 +115,7 @@ func (n *Nanny) handle(s validSignal) error {
 			}
 
 			// Call callback if set.
-			if s.CallbackFunc != nil {
+			if newTimer.signal.CallbackFunc != nil {
 				signal := Signal(newTimer.signal)
 				newTimer.signal.CallbackFunc(&signal)
 			}

--- a/pkg/nanny/nanny.go
+++ b/pkg/nanny/nanny.go
@@ -52,9 +52,9 @@ type nannyTimer struct {
 }
 
 // Reset updates the nannyTimers signal to reset the timer
-func (n *nannyTimer) Reset(s validSignal) {
-	n.signal = s
-	n.timer.Reset(s.NextSignal)
+func (n *nannyTimer) Reset(d time.Duration) {
+	n.signal.NextSignal = d
+	n.timer.Reset(d)
 }
 
 // defaultErrorFunc is used when no Nanny.ErrorFunc is specified, it simply prints
@@ -97,7 +97,7 @@ func (n *Nanny) handle(s validSignal) error {
 	if timer != nil {
 		// Timer exists, reset the timer to the new signal value.
 		n.lock.Lock()
-		timer.Reset(s)
+		timer.Reset(s.NextSignal)
 		n.lock.Unlock()
 	} else {
 		// No timer is registered for this program, create it.

--- a/pkg/nanny/nanny.go
+++ b/pkg/nanny/nanny.go
@@ -84,7 +84,7 @@ func (n *Nanny) handle(s validSignal) error {
 		timer.Reset(s.NextSignal)
 	} else {
 		// No timer is registered for this program, create it.
-		n.SetTimer(s.Name, newNannyTimer(s, n))
+		n.SetTimer(s.Name, newTimer(s, n))
 	}
 
 	return nil
@@ -92,15 +92,15 @@ func (n *Nanny) handle(s validSignal) error {
 
 // GetTimer returns time.Timer when given program name is already registered or
 // nil.
-func (n *Nanny) GetTimer(name string) *nannyTimer {
+func (n *Nanny) GetTimer(name string) *Timer {
 	value, ok := n.timers.GetStringKey(name)
 	if !ok {
 		return nil
 	}
-	return value.(*nannyTimer)
+	return value.(*Timer)
 }
 
 // SetTimer sets new timer for given program name.
-func (n *Nanny) SetTimer(name string, timer *nannyTimer) {
+func (n *Nanny) SetTimer(name string, timer *Timer) {
 	n.timers.Set(name, timer)
 }

--- a/pkg/nanny/nanny.go
+++ b/pkg/nanny/nanny.go
@@ -2,7 +2,6 @@ package nanny
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"nanny/pkg/notifier"
@@ -19,8 +18,6 @@ type Nanny struct {
 	// If not specified, uses defaultErrorFunc.
 	ErrorFunc ErrorFunc
 	timers    hashmap.HashMap // Map of program names (Signal.Name) to their timers.
-
-	lock sync.Mutex
 }
 
 // Signal represents program calling nanny to notify with given notifier if

--- a/pkg/nanny/nanny_test.go
+++ b/pkg/nanny/nanny_test.go
@@ -280,10 +280,10 @@ func TestMsgChange(t *testing.T) {
 }
 
 func TestNannyTimer(t *testing.T) {
-	n := nanny.Nanny{Name: "test msg changing nanny"}
+	n := nanny.Nanny{Name: "test nanny nannyTimer"}
 	dummy := &DummyNotifier{}
 	signal := nanny.Signal{
-		Name:         "test msg changing program",
+		Name:         "test nannyTimer",
 		Notifier:     dummy,
 		NextSignal:   time.Duration(2) * time.Second,
 		CallbackFunc: func(s *nanny.Signal) {},
@@ -294,7 +294,7 @@ func TestNannyTimer(t *testing.T) {
 	}
 
 	// Trigger the first signal's error.
-	time.Sleep(time.Duration(2) * time.Second)
+	time.Sleep(time.Duration(2)*time.Second + time.Duration(100)*time.Millisecond)
 
 	// Before the `NextSignal` duration, nothing should happen.
 	dummyMsg := dummy.NotifyMsg()
@@ -303,7 +303,7 @@ func TestNannyTimer(t *testing.T) {
 	}
 	// Call handle with different nextsignal again to simulate program calling before notification.
 	err = n.Handle(nanny.Signal{
-		Name:         "test msg changing program",
+		Name:         "test nannyTimer",
 		Notifier:     dummy,
 		NextSignal:   time.Duration(1) * time.Second,
 		CallbackFunc: func(s *nanny.Signal) {},
@@ -320,6 +320,6 @@ func TestNannyTimer(t *testing.T) {
 
 	msg := dummyMsg.Format()
 	if strings.Contains(msg, "2s") {
-		t.Errorf("dummy msg should not contain 1s after NextSignal time expired: %v\n", dummyMsg)
+		t.Errorf("dummy msg should not contain 2s after NextSignal time expired: %v\n", dummyMsg)
 	}
 }

--- a/pkg/nanny/nanny_test.go
+++ b/pkg/nanny/nanny_test.go
@@ -2,6 +2,7 @@ package nanny_test
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -234,5 +235,46 @@ func TestMultipleTimerResets(t *testing.T) {
 	dummyMsg = dummy.NotifyMsg()
 	if dummyMsg.Program == "" {
 		t.Errorf("dummy msg should not be empty after NextSignal time expired: %v\n", dummyMsg)
+	}
+}
+
+func TestMsgChange(t *testing.T) {
+	n := nanny.Nanny{Name: "test msg changing nanny"}
+	dummy := &DummyNotifier{}
+	signal := nanny.Signal{
+		Name:       "test msg changing program",
+		Notifier:   dummy,
+		NextSignal: time.Duration(2) * time.Second,
+	}
+
+	err := n.Handle(signal)
+	if err != nil {
+		t.Errorf("n.Signal should not return error, got: %v\n", err)
+	}
+
+	// Before the `NextSignal` duration, nothing should happen.
+	dummyMsg := dummy.NotifyMsg()
+	if dummyMsg.Program != "" {
+		t.Errorf("dummy msg should be empty before NextSignal time expires: %v\n", dummyMsg)
+	}
+	// Call handle with different nextsignal again to simulate program calling before notification.
+	err = n.Handle(nanny.Signal{
+		Name:       "test msg changing program",
+		Notifier:   dummy,
+		NextSignal: time.Duration(1) * time.Second,
+	})
+	if err != nil {
+		t.Errorf("n.Signal should not return error, got: %v\n", err)
+	}
+	// After 1s, DummyNotifier should return error.
+	time.Sleep(time.Duration(1)*time.Second + time.Duration(100)*time.Millisecond)
+	dummyMsg = dummy.NotifyMsg()
+	if dummyMsg.Program == "" {
+		t.Errorf("dummy msg should not be empty after NextSignal time expired: %v\n", dummyMsg)
+	}
+
+	msg := dummyMsg.Format()
+	if strings.Contains(msg, "2s") {
+		t.Errorf("dummy msg should not contain 1s after NextSignal time expired: %v\n", dummyMsg)
 	}
 }

--- a/pkg/nanny/timer.go
+++ b/pkg/nanny/timer.go
@@ -1,0 +1,64 @@
+package nanny
+
+import (
+	"nanny/pkg/notifier"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// NannyTimer encapsulates a signal and its timer
+type nannyTimer struct {
+	signal validSignal
+	timer  *time.Timer
+	nanny  *Nanny
+
+	errorFunc ErrorFunc
+}
+
+func newNannyTimer(s validSignal, nanny *Nanny) *nannyTimer {
+	timer := &nannyTimer{signal: s, nanny: nanny}
+	timer.timer = time.AfterFunc(timer.signal.NextSignal, timer.onExpire)
+	return timer
+}
+
+// Reset updates the nannyTimers signal to reset the timer
+func (nt *nannyTimer) Reset(d time.Duration) {
+	nt.nanny.lock.Lock()
+	nt.signal.NextSignal = d
+	nt.timer.Reset(d)
+	nt.nanny.lock.Unlock()
+}
+
+func (nt *nannyTimer) onExpire() {
+	err := nt.notify()
+	if err != nil {
+		// Add context to the error message and call ErrorFunc.
+		err = errors.Wrapf(err, "error calling notifier: %T with signal: %+v", nt.signal.Notifier, nt.signal)
+		if nt.errorFunc == nil {
+			defaultErrorFunc(err)
+		} else {
+			nt.errorFunc(err)
+		}
+	}
+
+	// Call callback if set.
+	if nt.signal.CallbackFunc != nil {
+		signal := Signal(nt.signal)
+		nt.signal.CallbackFunc(&signal)
+	}
+}
+
+func (nt *nannyTimer) notify() error {
+	name := "Nanny"
+	if nt.nanny.Name != "" {
+		name = nt.nanny.Name
+	}
+
+	return nt.signal.Notifier.Notify(notifier.Message{
+		Nanny:      name,
+		Program:    nt.signal.Name,
+		NextSignal: nt.signal.NextSignal,
+		Meta:       nt.signal.Meta,
+	})
+}

--- a/pkg/nanny/timer.go
+++ b/pkg/nanny/timer.go
@@ -33,6 +33,9 @@ func (nt *nannyTimer) Reset(d time.Duration) {
 }
 
 func (nt *nannyTimer) onExpire() {
+	nt.lock.Lock()
+	defer nt.lock.Unlock()
+
 	err := nt.notify()
 	if err != nil {
 		// Add context to the error message and call ErrorFunc.
@@ -46,8 +49,6 @@ func (nt *nannyTimer) onExpire() {
 
 	// Call callback if set.
 	if nt.signal.CallbackFunc != nil {
-		nt.lock.Lock()
-		defer nt.lock.Unlock()
 		signal := Signal(nt.signal)
 		nt.signal.CallbackFunc(&signal)
 	}

--- a/pkg/nanny/timer.go
+++ b/pkg/nanny/timer.go
@@ -33,9 +33,6 @@ func (nt *nannyTimer) Reset(d time.Duration) {
 }
 
 func (nt *nannyTimer) onExpire() {
-	nt.lock.Lock()
-	defer nt.lock.Unlock()
-
 	err := nt.notify()
 	if err != nil {
 		// Add context to the error message and call ErrorFunc.
@@ -48,13 +45,17 @@ func (nt *nannyTimer) onExpire() {
 	}
 
 	// Call callback if set.
+	nt.lock.Lock()
 	if nt.signal.CallbackFunc != nil {
 		signal := Signal(nt.signal)
 		nt.signal.CallbackFunc(&signal)
 	}
+	nt.lock.Unlock()
 }
 
 func (nt *nannyTimer) notify() error {
+	nt.lock.Lock()
+	defer nt.lock.Unlock()
 	name := "Nanny"
 	if nt.nanny.Name != "" {
 		name = nt.nanny.Name

--- a/pkg/nanny/timer.go
+++ b/pkg/nanny/timer.go
@@ -8,8 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NannyTimer encapsulates a signal and its timer
-type nannyTimer struct {
+// Timer encapsulates a signal and its timer
+type Timer struct {
 	signal validSignal
 	timer  *time.Timer
 	nanny  *Nanny
@@ -17,14 +17,14 @@ type nannyTimer struct {
 	lock sync.Mutex
 }
 
-func newNannyTimer(s validSignal, nanny *Nanny) *nannyTimer {
-	timer := &nannyTimer{signal: s, nanny: nanny}
+func newTimer(s validSignal, nanny *Nanny) *Timer {
+	timer := &Timer{signal: s, nanny: nanny}
 	timer.timer = time.AfterFunc(timer.signal.NextSignal, timer.onExpire)
 	return timer
 }
 
 // Reset updates the nannyTimers signal to reset the timer
-func (nt *nannyTimer) Reset(d time.Duration) {
+func (nt *Timer) Reset(d time.Duration) {
 	nt.lock.Lock()
 	defer nt.lock.Unlock()
 
@@ -32,7 +32,7 @@ func (nt *nannyTimer) Reset(d time.Duration) {
 	nt.timer.Reset(d)
 }
 
-func (nt *nannyTimer) onExpire() {
+func (nt *Timer) onExpire() {
 	err := nt.notify()
 	if err != nil {
 		// Add context to the error message and call ErrorFunc.
@@ -53,7 +53,7 @@ func (nt *nannyTimer) onExpire() {
 	nt.lock.Unlock()
 }
 
-func (nt *nannyTimer) notify() error {
+func (nt *Timer) notify() error {
 	nt.lock.Lock()
 	defer nt.lock.Unlock()
 	name := "Nanny"


### PR DESCRIPTION
I plan to use nanny to monitor processes that rune once a day, so my I guess it should be possible to:

- Notify nanny upon start of the process (say at 8am) with next_signal set to `10m` because I know if the process does not finish in 10 minutes, there is something wrong
- Notify nanny upon end of the process (8:07 am) with next_signal set to `23h53m10s` to alert if the process hasn't been started at 8am next day

But nanny only reports the next signal of the very first occurence of the signal

This pull request introduces a new struct which wraps a time.Timer together with its signal to be able to have the most recent NextSignal value available for messaging. 