### PR TITLE
read X-Forwarded-For Header before using req.RemoteAddr for name

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -287,8 +287,12 @@ func signalHandler(n *nanny.Nanny, notifiers notifiers, store storage.Storage, w
 }
 
 func constructSignal(jsonSignal Signal, notif notifier.Notifier, store storage.Storage, req *http.Request) nanny.Signal {
+	remoteAddr := req.Header.Get("X-Forwarded-For")
+	if remoteAddr == "" {
+		remoteAddr = req.RemoteAddr
+	}
 	s := nanny.Signal{
-		Name:       constructName(jsonSignal.Name, req.RemoteAddr),
+		Name:       constructName(jsonSignal.Name, remoteAddr),
 		Notifier:   notif,
 		NextSignal: constructDuration(jsonSignal.NextSignal),
 		Meta:       jsonSignal.Meta,


### PR DESCRIPTION
This pull request reads the value of the X-Forwarded-For header to construct the name of the Signal.

This is useful for situations where nanny is running behind a Proxy or inside a container.