### PR TITLE
Allow updating the meta data through consecutive api calls

### DIFF
--- a/pkg/nanny/nanny.go
+++ b/pkg/nanny/nanny.go
@@ -81,7 +81,7 @@ func (n *Nanny) handle(s validSignal) error {
 
 	if timer != nil {
 		// Timer exists, reset the timer to the new signal value.
-		timer.Reset(s.NextSignal)
+		timer.Reset(s)
 	} else {
 		// No timer is registered for this program, create it.
 		n.SetTimer(s.Name, newTimer(s, n))

--- a/pkg/nanny/timer.go
+++ b/pkg/nanny/timer.go
@@ -24,12 +24,13 @@ func newTimer(s validSignal, nanny *Nanny) *Timer {
 }
 
 // Reset updates the nannyTimers signal to reset the timer
-func (nt *Timer) Reset(d time.Duration) {
+func (nt *Timer) Reset(vs validSignal) {
 	nt.lock.Lock()
 	defer nt.lock.Unlock()
 
-	nt.signal.NextSignal = d
-	nt.timer.Reset(d)
+	nt.signal.NextSignal = vs.NextSignal
+	nt.signal.Meta = vs.Meta
+	nt.timer.Reset(vs.NextSignal)
 }
 
 func (nt *Timer) onExpire() {


### PR DESCRIPTION
This pull request contains changes which enable to update the metadata of already running timers through the HTTP API.

The `meta` field of the signal is a perfect place for stuff like telling exactly where inside a process things went wrong. Its a bit like println bases debugging but allows to transfer more information to the notified person.

I simply tested with the following commands

    curl --data '{ "meta": { "ping": "pong" }, "name": "my awesome program", "notifier": "stderr", "next_signal": "5s" }' http://localhost:8080/api/v1/signal
    curl --data '{ "meta": { "foo": "bar" }, "name": "my awesome program", "notifier": "stderr", "next_signal": "5s" }' http://localhost:8080/api/v1/signal

Expected stderr:

    Nanny: I did not hear from "my awesome program@127.0.0.1" in 5s! (Meta: map[foo:bar])

Actual stderr:

    Nanny: I did not hear from "my awesome program@127.0.0.1" in 5s! (Meta: map[ping:pong])

I changed the signature of `nanny.Timer.Reset` from taking a `time.Duration` to taking a `validSignal`. This is in contrast to the discussion in #11 but I think now it makes more sense to call the `Reset` function with the whole signal.
