### PR TITLE
Proposal: Add /api/v1/signals endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ NANNY_NAME="custom name" NANNY_ADDR="localhost:9090" LOGXI=* ./nanny
   /api/version
 
 * **Method:**
-  
+
   `GET`
-  
+
 * **Success Response:**
-  
-  * **Code:** 200  
+
+  * **Code:** 200
     **Content:** `Nanny vX.Y`
 
 ### Signal
@@ -94,9 +94,9 @@ NANNY_NAME="custom name" NANNY_ADDR="localhost:9090" LOGXI=* ./nanny
   /api/v1/signal
 
 * **Method:**
-  
+
   `POST`
-  
+
 * **Data Params**
   ```js
   {
@@ -110,18 +110,54 @@ NANNY_NAME="custom name" NANNY_ADDR="localhost:9090" LOGXI=* ./nanny
   ```
 
 * **Success Response:**
-  
-  * **Code:** 200  
-    **Content:** 
- 
+
+  * **Code:** 200
+    **Content:**
+
 * **Error Response:**
-  * **Code:** 400 Bad Request  
+  * **Code:** 400 Bad Request
     **Content:** `{"status_code":400,"error":"unable to find notifier: "}`
 
   OR
 
-  * **Code:** 500 Internal Server Error  
+  * **Code:** 500 Internal Server Error
     **Content:** `Message describing error, may be JSON or may be text.`
+
+### Current signals
+  Return current signals as JSON.
+
+* **URL**
+
+  /api/v1/signals
+
+* **Method:**
+
+  `GET`
+
+* **Success Response:**
+
+  * **Code:** 200
+    **Content:**
+    ```
+    {
+      "nanny_name": "Nanny",
+      "signals": [
+        {
+          "name": "my awesome program",
+          "notifier": "stderr",
+          "next_signal":"2018-08-21T10:00:15+02:00",
+          "meta": {
+            "current-step": "loading"
+          }
+        },
+        {
+          "name": "my awesome program without meta",
+          "notifier": "email",
+          "next_signal":"2018-08-21T09:45:00+02:00"
+        }
+      ]
+    }
+    ```
 
 ## Monitoring nanny
 You can use one Nanny to monitor another Nanny or create a monitored Nanny-pair.

--- a/api/api.go
+++ b/api/api.go
@@ -294,7 +294,7 @@ func getSignalsHandler(n *nanny.Nanny, notifiers notifiers, store storage.Storag
 
 	err := json.NewEncoder(w).Encode(&struct {
 		NannyName string         `json:"nanny_name"`
-		Programs  []*nanny.Timer `json:"programs"`
+		Programs  []*nanny.Timer `json:"signals"`
 	}{
 		NannyName: n.Name,
 		Programs:  signals,

--- a/pkg/nanny/nanny.go
+++ b/pkg/nanny/nanny.go
@@ -104,3 +104,14 @@ func (n *Nanny) GetTimer(name string) *Timer {
 func (n *Nanny) SetTimer(name string, timer *Timer) {
 	n.timers.Set(name, timer)
 }
+
+// GetTimers returns a slice of currently open timers
+func (n *Nanny) GetTimers() []*Timer {
+	timers := make([]*Timer, n.timers.Len())
+	index := 0
+	for timer := range n.timers.Iter() {
+		timers[index] = timer.Value.(*Timer)
+		index = index + 1
+	}
+	return timers
+}

--- a/pkg/nanny/nanny_test.go
+++ b/pkg/nanny/nanny_test.go
@@ -26,6 +26,10 @@ func (d *DummyNotifier) Notify(msg notifier.Message) error {
 	return nil
 }
 
+func (d *DummyNotifier) String() string {
+	return "dummy"
+}
+
 // NotifyMsg retrieves `msg` argument from previous `Notify` call. For testing
 // purposes only.
 func (d *DummyNotifier) NotifyMsg() notifier.Message {
@@ -40,6 +44,10 @@ type DummyNotifierWithError struct{}
 // Notify satisfies Notifier interface.
 func (d *DummyNotifierWithError) Notify(msg notifier.Message) error {
 	return fmt.Errorf("error")
+}
+
+func (d *DummyNotifierWithError) String() string {
+	return "dummy with error"
 }
 
 func TestNanny(t *testing.T) {

--- a/pkg/nanny/nanny_test.go
+++ b/pkg/nanny/nanny_test.go
@@ -449,7 +449,7 @@ func TestTimerMarshalJSONMetaNotPresent(t *testing.T) {
 		t.Errorf("json.Marshal should not return error, got: %v\n", err)
 	}
 
-	if strings.Contains(string(jsonBytes), "meta") {
+	if strings.Contains(string(jsonBytes), "\"meta\":") {
 		t.Error("expected json representation to not contain \"meta\"")
 	}
 }
@@ -469,7 +469,7 @@ func TestTimerMarshalJSONMeta(t *testing.T) {
 	}
 	jsonString := string(jsonBytes)
 
-	for _, required := range []string{"meta", "key", "value"} {
+	for _, required := range []string{"\"meta\":", "\"key\":\"value\""} {
 		if strings.Contains(jsonString, required) == false {
 			t.Errorf("expected json representation to contain \"%s\"", required)
 		}

--- a/pkg/nanny/timer.go
+++ b/pkg/nanny/timer.go
@@ -48,6 +48,7 @@ func (nt *Timer) Reset(vs validSignal) {
 
 	nt.signal.NextSignal = vs.NextSignal
 	nt.signal.Meta = vs.Meta
+	nt.end = time.Now().Add(vs.NextSignal)
 	nt.timer.Reset(vs.NextSignal)
 }
 

--- a/pkg/nanny/timer.go
+++ b/pkg/nanny/timer.go
@@ -1,6 +1,7 @@
 package nanny
 
 import (
+	"encoding/json"
 	"nanny/pkg/notifier"
 	"sync"
 	"time"
@@ -13,12 +14,29 @@ type Timer struct {
 	signal validSignal
 	timer  *time.Timer
 	nanny  *Nanny
+	end    time.Time
 
 	lock sync.Mutex
 }
 
+// MarshalJSON marshals a nanny.Timer into JSON. Fields name, notifier, next_signal and meta are exported
+func (nt *Timer) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Name       string            `json:"name"`
+		Notifier   string            `json:"notifier"`
+		NextSignal string            `json:"next_signal"`
+		Meta       map[string]string `json:"meta,omitempty"`
+	}{
+		Name:       nt.signal.Name,
+		Notifier:   nt.signal.Notifier.String(),
+		NextSignal: nt.end.Format(time.RFC3339),
+		Meta:       nt.signal.Meta,
+	})
+}
+
 func newTimer(s validSignal, nanny *Nanny) *Timer {
 	timer := &Timer{signal: s, nanny: nanny}
+	timer.end = time.Now().Add(timer.signal.NextSignal)
 	timer.timer = time.AfterFunc(timer.signal.NextSignal, timer.onExpire)
 	return timer
 }

--- a/pkg/notifier/email.go
+++ b/pkg/notifier/email.go
@@ -37,3 +37,8 @@ func (n *Email) Notify(msg Message) error {
 	}
 	return nil
 }
+
+// MarshalJSON marshals the Email notifier into its name "email"
+func (n *Email) String() string {
+	return "email"
+}

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -8,6 +8,7 @@ import (
 // Notifier interface is used by Nanny to notify user on different outputs/services.
 type Notifier interface {
 	Notify(Message) error
+	String() string
 }
 
 // Message is used with Notifier's Notify to customise messages sent via different

--- a/pkg/notifier/sentry.go
+++ b/pkg/notifier/sentry.go
@@ -24,3 +24,7 @@ func (n *sentry) Notify(msg Message) error {
 	n.cli.CaptureMessageAndWait(msg.Format(), msg.Meta)
 	return nil
 }
+
+func (n *sentry) String() string {
+	return "sentry"
+}

--- a/pkg/notifier/slack.go
+++ b/pkg/notifier/slack.go
@@ -53,3 +53,7 @@ func (s *slackNotifier) Notify(msg Message) error {
 	}
 	return nil
 }
+
+func (s *slackNotifier) String() string {
+	return "slack"
+}

--- a/pkg/notifier/stderr.go
+++ b/pkg/notifier/stderr.go
@@ -17,3 +17,8 @@ func (n *StdErr) Notify(msg Message) error {
 	_, err := os.Stderr.WriteString(text)
 	return errors.Wrap(err, "unable to notify via stderr")
 }
+
+// MarshalJSON marshals the stderr notifier into a "stderr" string
+func (n *StdErr) String() string {
+	return "stderr"
+}

--- a/pkg/notifier/twilio.go
+++ b/pkg/notifier/twilio.go
@@ -40,3 +40,7 @@ func (n *twilio) Notify(msg Message) error {
 	}
 	return nil
 }
+
+func (n *twilio) String() string {
+	return "twilio"
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,8 +16,8 @@ type Storage interface {
 
 // Signal represents stored signal information
 type Signal struct {
-	Name       string            `xorm:"pk" json:"name"`
-	Notifier   string            `json:"notifier"`
-	NextSignal time.Time         `json:"next_signal"`
-	Meta       map[string]string `json:"meta,omitempty"`
+	Name       string `xorm:"pk"`
+	Notifier   string
+	NextSignal time.Time
+	Meta       map[string]string
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,8 +16,8 @@ type Storage interface {
 
 // Signal represents stored signal information
 type Signal struct {
-	Name       string `xorm:"pk"`
-	Notifier   string
-	NextSignal time.Time
-	Meta       map[string]string
+	Name       string            `xorm:"pk" json:"name"`
+	Notifier   string            `json:"notifier"`
+	NextSignal time.Time         `json:"next_signal"`
+	Meta       map[string]string `json:"meta,omitempty"`
 }


### PR DESCRIPTION
@lunemec @PhilipSchmid 
This pull request add a new http GET endpoint `/api/v1/signals` which returns a JSON encoded response about the current active timers.

With this, one could create a HTML status page displaying the current active timers with their expected next signals

What do you think? This is just quickly whipped together nothing set in stone.