### PR TITLE
Implement way to disable appending IP to program names

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ NANNY_NAME="custom name" NANNY_ADDR="localhost:9090" LOGXI=* ./nanny
 
   `POST`
 
+* **Headers:**
+
+  `X-Dont-Modify-Name: true` If specified, Nanny won't modify the `name` specified in the JSON payload. Useful when your signals come from programs with dynamic IP addresses.
+
 * **Data Params**
   ```js
   {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -164,3 +164,19 @@ func TestAPISignalAcceptsInt(t *testing.T) {
 
 // TODO
 func TestPersistence(t *testing.T) {}
+
+func TestConstructName(t *testing.T) {
+	signalName := "test_name"
+	r, _ := http.NewRequest("POST", "/ignored/anyway", nil)
+	r.RemoteAddr = "10.11.12.13:8089"
+
+	assert.Equal(t, constructName(signalName, r), "test_name@10.11.12.13")
+
+	r.Header = map[string][]string{"X-Forwarded-For": {"14.15.16.17"}}
+
+	assert.Equal(t, constructName(signalName, r), "test_name@14.15.16.17")
+
+	r.Header["X-Dont-Modify-Name"] = []string{"true"}
+
+	assert.Equal(t, constructName(signalName, r), signalName)
+}


### PR DESCRIPTION
This pull requests adds reading the`X-Dont-Modify-Name` HTTP header from requests to `/api/v1/signal` which changes the behaviour of signal name construction.

Without specifying the header, the behaviour is the same as before the pull request. 

If the header is present, name modification (namely appending the IP to the name) gets disabled.

This is a use case for me because I am monitoring "moving targets" with dynamic IP addresses.