### PR TITLE
Add optional all-clear notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ $ LOGXI=* ./nanny
 ```
 Call it via curl:
 ```bash
-curl http://localhost:8080/api/v1/signal --data '{ "name": "my awesome program", "notifier": "stderr", "next_signal": "5s" }'
+curl http://localhost:8080/api/v1/signal --data '{ "name": "my awesome program", "notifier": "stderr", "next_signal": "5s", "all_clear": false }'
 ```
-With this call, you tell nanny that if program named `my awesome program` does not call again within `next_signal` (5s), it should notify you using `stderr` notifier. Additionally, nanny appends the IP or `X-Forwarded-For` HTTP header to the program name. You can disable this behaviour by sending a `X-Dont-Modify-Name` along with the request.
+With this call, you tell nanny that if program named `my awesome program` does not call again within `next_signal` (5s), it should notify you using `stderr` notifier. Additionally, nanny appends the IP or `X-Forwarded-For` HTTP header to the program name. You can disable this behaviour by sending a `X-Dont-Modify-Name` along with the request. If you activate `all_clear` you will get an additional notification when the program sends a signal to nanny for the first time after an alert was sent.
 
 After 5s pass, nanny prints to *stderr*:
 ```bash
@@ -109,6 +109,7 @@ NANNY_NAME="custom name" NANNY_ADDR="localhost:9090" LOGXI=* ./nanny
     "name": "name of monitored program",
     "notifier": "stderr", # You can use only enabled notifiers, see config.
     "next_signal": "55s", # When to expect next call (or notify).
+    "all_clear": false,   # Optional all-clear notification when a call is received after an alert was sent
     "meta": {             # Meta can contain any string:string values,
       "extra": "data"     # they are passed to the notifiers and will eventually
     }                     # be passed to the user.
@@ -149,17 +150,19 @@ NANNY_NAME="custom name" NANNY_ADDR="localhost:9090" LOGXI=* ./nanny
       "nanny_name": "Nanny",
       "signals": [
         {
-          "name": "my awesome program",
-          "notifier": "stderr",
+          "name":"my awesome program",
+          "notifier":"stderr",
           "next_signal":"2018-08-21T10:00:15+02:00",
+          "all_clear":false,
           "meta": {
             "current-step": "loading"
           }
         },
         {
-          "name": "my awesome program without meta",
-          "notifier": "email",
-          "next_signal":"2018-08-21T09:45:00+02:00"
+          "name":"my awesome program without meta",
+          "notifier":"email",
+          "next_signal":"2018-08-21T09:45:00+02:00",
+          "all_clear":false
         }
       ]
     }
@@ -190,7 +193,7 @@ By default, nanny logs only errors. To enable more verbose logging, use `LOGXI=*
 You can add extra meta-data to the API calls, which will be passed to all the notifiers. Metadata must conform to type `map[string]string`.
 
 ```bash
-curl http://localhost:8080/api/v1/signal --data '{ "name": "my program", "notifier": "stderr", "next_signal": "5s", "meta":{"custom": "metadata"} }'
+curl http://localhost:8080/api/v1/signal --data '{ "name": "my program", "notifier": "stderr", "next_signal": "5s", "all_clear": false, "meta":{"custom": "metadata"} }'
 ```
 
 These metadata will be displayed in the messages for stderr and email, and in tags for sentry.

--- a/api/api.go
+++ b/api/api.go
@@ -37,8 +37,10 @@ type Signal struct {
 	Notifier string `json:"notifier"` // What notifier to use.
 	// After how many seconds to expect next call.
 	// May contain "10s", "1h": https://golang.org/pkg/time/#ParseDuration
-	NextSignal string            `json:"next_signal"`
-	Meta       map[string]string `json:"meta"` // Metadata for this signal, may contain custom data.
+	NextSignal string `json:"next_signal"`
+	// Activate optional all-clear notification that is sent when a call is received after an alert was sent
+	AllClear bool              `json:"all_clear"`
+	Meta     map[string]string `json:"meta"` // Metadata for this signal, may contain custom data.
 }
 
 // Error represents JSON error to be sent to user.
@@ -103,16 +105,18 @@ func loadStorage(n *nanny.Nanny, notifiers notifiers, store storage.Storage) {
 
 	// Create nanny timers from persisted signals.
 	for _, signal := range signals {
-		// If NextSignal would be in the past, notify user, and delete it.
+		// If NextSignal would be in the past, notify user, and delete it if all-clear notification is not activated.
 		if signal.NextSignal.Before(time.Now()) {
 			msg := "Found previously stored notifier that is stale. Please check " +
 				"this program manually."
 			log.Warn(msg, "program", signal.Name, "should_notify", signal.NextSignal.String())
-			err = store.Remove(signal)
-			if err != nil {
-				log.Error("Unable to remove stale signal.", "err", err)
+			if !signal.AllClear {
+				err = store.Remove(signal)
+				if err != nil {
+					log.Error("Unable to remove stale signal.", "err", err)
+				}
+				continue
 			}
-			continue
 		}
 
 		notif, ok := notifiers[signal.Notifier]
@@ -125,6 +129,7 @@ func loadStorage(n *nanny.Nanny, notifiers notifiers, store storage.Storage) {
 			Name:       signal.Name,
 			Notifier:   notif,
 			NextSignal: time.Until(signal.NextSignal),
+			AllClear:   signal.AllClear,
 			Meta:       signal.Meta,
 
 			CallbackFunc: callbackFunc,
@@ -140,6 +145,7 @@ func loadStorage(n *nanny.Nanny, notifiers notifiers, store storage.Storage) {
 		log.Info("Loaded persisted signal successful.",
 			"program", signal.Name,
 			"next_signal", s.NextSignal.String(),
+			"all_clear", s.AllClear,
 			"meta", s.Meta,
 			"notifier", signal.Notifier)
 	}
@@ -150,9 +156,11 @@ func loadStorage(n *nanny.Nanny, notifiers notifiers, store storage.Storage) {
 // storage.
 func makeCallbackFunc(store storage.Storage) func(*nanny.Signal) {
 	return func(signal *nanny.Signal) {
-		err := store.Remove(storage.Signal{Name: signal.Name})
-		if err != nil {
-			log.Error("Error removing signal from storage.", "err", err, "signal", signal)
+		if !signal.AllClear {
+			err := store.Remove(storage.Signal{Name: signal.Name})
+			if err != nil {
+				log.Error("Error removing signal from storage.", "err", err, "signal", signal)
+			}
 		}
 	}
 }
@@ -232,6 +240,7 @@ func signalHandler(n *nanny.Nanny, notifiers notifiers, store storage.Storage, w
 		Name:       s.Name,
 		Notifier:   signal.Notifier,
 		NextSignal: time.Now().Add(s.NextSignal),
+		AllClear:   s.AllClear,
 		Meta:       s.Meta,
 	})
 
@@ -274,12 +283,15 @@ func constructSignal(jsonSignal Signal, notif notifier.Notifier, store storage.S
 		Name:       constructName(jsonSignal.Name, req),
 		Notifier:   notif,
 		NextSignal: constructDuration(jsonSignal.NextSignal),
+		AllClear:   jsonSignal.AllClear,
 		Meta:       jsonSignal.Meta,
 
 		CallbackFunc: func(s *nanny.Signal) {
-			err := store.Remove(storage.Signal{Name: s.Name})
-			if err != nil {
-				log.Error("Error removing signal from storage.", "err", err, "signal", jsonSignal)
+			if !s.AllClear {
+				err := store.Remove(storage.Signal{Name: s.Name})
+				if err != nil {
+					log.Error("Error removing signal from storage.", "err", err, "signal", jsonSignal)
+				}
 			}
 		},
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -34,6 +34,14 @@ func (d *DummyNotifier) Notify(msg notifier.Message) error {
 	return nil
 }
 
+// NotifyAllClear stores `msg` in the DummyNotifier.
+func (d *DummyNotifier) NotifyAllClear(msg notifier.Message) error {
+	d.lock.Lock()
+	d.notifyMsg = msg
+	d.lock.Unlock()
+	return nil
+}
+
 func (d *DummyNotifier) String() string {
 	return "dummy"
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"nanny/pkg/storage"
 	"net/http"
 	"os"
 	"os/signal"
@@ -14,6 +13,7 @@ import (
 	"nanny/api"
 	"nanny/pkg/closer"
 	"nanny/pkg/notifier"
+	"nanny/pkg/storage"
 
 	log "github.com/mgutz/logxi"
 	"github.com/pkg/errors"
@@ -41,15 +41,16 @@ type Stderr struct {
 
 // Email notifier config.
 type Email struct {
-	Enabled      bool
-	From         string
-	To           []string
-	Subject      string
-	Body         string
-	SMTPServer   string `mapstructure:"smtp_server"`
-	SMTPPort     int    `mapstructure:"smtp_port"`
-	SMTPUser     string `mapstructure:"smtp_user"`
-	SMTPPassword string `mapstructure:"smtp_password"`
+	Enabled         bool
+	From            string
+	To              []string
+	Subject         string
+	SubjectAllClear string `mapstructure:"subject_all_clear"`
+	Body            string
+	SMTPServer      string `mapstructure:"smtp_server"`
+	SMTPPort        int    `mapstructure:"smtp_port"`
+	SMTPUser        string `mapstructure:"smtp_user"`
+	SMTPPassword    string `mapstructure:"smtp_password"`
 }
 
 // Sentry notifier config.
@@ -118,6 +119,7 @@ func nannyCheck(nanny string) {
 		Name:       config.Name,
 		Notifier:   otherNannyNotifier,
 		NextSignal: "1s",
+		AllClear:   false,
 		Meta:       map[string]string{"addr": config.Addr},
 	}
 	data, err := json.Marshal(&signal)
@@ -197,14 +199,15 @@ func makeNotifiers() (map[string]notifier.Notifier, error) {
 	}
 	if config.Email.Enabled {
 		notifiers["email"] = &notifier.Email{
-			From:     config.Email.From,
-			To:       config.Email.To,
-			Subject:  config.Email.Subject,
-			Body:     config.Email.Body,
-			Server:   config.Email.SMTPServer,
-			Port:     config.Email.SMTPPort,
-			User:     config.Email.SMTPUser,
-			Password: config.Email.SMTPPassword,
+			From:            config.Email.From,
+			To:              config.Email.To,
+			Subject:         config.Email.Subject,
+			SubjectAllClear: config.Email.SubjectAllClear,
+			Body:            config.Email.Body,
+			Server:          config.Email.SMTPServer,
+			Port:            config.Email.SMTPPort,
+			User:            config.Email.SMTPUser,
+			Password:        config.Email.SMTPPassword,
 		}
 	}
 	if config.Sentry.Enabled {

--- a/nanny.toml
+++ b/nanny.toml
@@ -12,6 +12,7 @@ enabled=false
 from="nanny@myserver.com"
 to=["someone@somewhere.com"]
 subject="Nanny alert for %s"
+subject_all_clear="Nanny all-clear for %s"
 body="%s"
 smtp_server="my.smtp.server"
 smtp_port=587

--- a/pkg/nanny/nanny.go
+++ b/pkg/nanny/nanny.go
@@ -28,6 +28,7 @@ type Signal struct {
 	Name       string
 	Notifier   notifier.Notifier // What notifier to use.
 	NextSignal time.Duration     // Notify after reaching this timeout.
+	AllClear   bool              // Activate optional all-clear notification
 	Meta       map[string]string
 
 	// Optional callback function that will be called when notifier is called.

--- a/pkg/nanny/nanny.go
+++ b/pkg/nanny/nanny.go
@@ -82,7 +82,12 @@ func (n *Nanny) handle(s validSignal) error {
 
 	if timer != nil {
 		// Timer exists, reset the timer to the new signal value.
-		timer.Reset(s)
+		// Send all-clear notification if requested
+		if s.AllClear && time.Now().After(timer.end) {
+			timer.ResetAllClear(s)
+		} else {
+			timer.Reset(s)
+		}
 	} else {
 		// No timer is registered for this program, create it.
 		n.SetTimer(s.Name, newTimer(s, n))

--- a/pkg/nanny/nanny_test.go
+++ b/pkg/nanny/nanny_test.go
@@ -27,6 +27,14 @@ func (d *DummyNotifier) Notify(msg notifier.Message) error {
 	return nil
 }
 
+// NotifyAllClear stores `msg` in the DummyNotifier.
+func (d *DummyNotifier) NotifyAllClear(msg notifier.Message) error {
+	d.lock.Lock()
+	d.notifyMsg = msg
+	d.lock.Unlock()
+	return nil
+}
+
 func (d *DummyNotifier) String() string {
 	return "dummy"
 }
@@ -44,6 +52,11 @@ type DummyNotifierWithError struct{}
 
 // Notify satisfies Notifier interface.
 func (d *DummyNotifierWithError) Notify(msg notifier.Message) error {
+	return fmt.Errorf("error")
+}
+
+// NotifyAllClear satisfies Notifier interface.
+func (d *DummyNotifierWithError) NotifyAllClear(msg notifier.Message) error {
 	return fmt.Errorf("error")
 }
 
@@ -390,7 +403,7 @@ func TestNannyAllClear(t *testing.T) {
 		t.Errorf("if all-clear is activated dummy msg should contain a message while time is not yet expired: %v\n", dummyMsg)
 	}
 
-	msg := dummyMsg.Format()
+	msg := dummyMsg.FormatAllClear()
 	if !strings.Contains(msg, "did hear") {
 		t.Errorf("dummy msg should contain all-clear: %v\n", dummyMsg)
 	}

--- a/pkg/nanny/nanny_test.go
+++ b/pkg/nanny/nanny_test.go
@@ -58,7 +58,6 @@ func createTimer(nannyName, signalName string, duration time.Duration, meta map[
 		Name:         signalName,
 		Notifier:     dummy,
 		NextSignal:   duration,
-		AllClear:     false,
 		CallbackFunc: func(s *nanny.Signal) {},
 		Meta:         meta,
 	})
@@ -75,7 +74,6 @@ func TestNanny(t *testing.T) {
 		Name:       "test program",
 		Notifier:   dummy,
 		NextSignal: time.Duration(1) * time.Second,
-		AllClear:   false,
 	}
 
 	err := n.Handle(signal)
@@ -105,7 +103,6 @@ func TestNannyDoesNotNotify(t *testing.T) {
 		Name:       "test program",
 		Notifier:   dummy,
 		NextSignal: time.Duration(1) * time.Second,
-		AllClear:   false,
 	}
 
 	err := n.Handle(signal)
@@ -166,7 +163,6 @@ func TestNannyCallsErrorFunc(t *testing.T) {
 		Name:       "test program",
 		Notifier:   dummy,
 		NextSignal: time.Duration(1) * time.Second,
-		AllClear:   false,
 	}
 
 	err := n.Handle(signal)
@@ -210,7 +206,6 @@ func TestConcurrent(t *testing.T) {
 				Name:       fmt.Sprintf("test program %d", num),
 				Notifier:   dummy,
 				NextSignal: time.Duration(1) * time.Second,
-				AllClear:   false,
 			}
 
 			err := n.Handle(signal)
@@ -242,7 +237,6 @@ func TestMultipleTimerResets(t *testing.T) {
 		Name:       "test program",
 		Notifier:   dummy,
 		NextSignal: time.Duration(1) * time.Second,
-		AllClear:   false,
 	}
 
 	runHandle := func() {
@@ -276,7 +270,6 @@ func TestMsgChange(t *testing.T) {
 		Name:       "test msg changing program",
 		Notifier:   dummy,
 		NextSignal: time.Duration(2) * time.Second,
-		AllClear:   false,
 	}
 
 	err := n.Handle(signal)
@@ -294,7 +287,6 @@ func TestMsgChange(t *testing.T) {
 		Name:       "test msg changing program",
 		Notifier:   dummy,
 		NextSignal: time.Duration(1) * time.Second,
-		AllClear:   false,
 	})
 	if err != nil {
 		t.Errorf("n.Signal should not return error, got: %v\n", err)
@@ -319,7 +311,6 @@ func TestNannyTimer(t *testing.T) {
 		Name:         "test nannyTimer",
 		Notifier:     dummy,
 		NextSignal:   time.Duration(2) * time.Second,
-		AllClear:     false,
 		CallbackFunc: func(s *nanny.Signal) {},
 	}
 	err := n.Handle(signal)
@@ -340,7 +331,6 @@ func TestNannyTimer(t *testing.T) {
 		Name:         "test nannyTimer",
 		Notifier:     dummy,
 		NextSignal:   time.Duration(1) * time.Second,
-		AllClear:     false,
 		CallbackFunc: func(s *nanny.Signal) {},
 	})
 	if err != nil {
@@ -424,7 +414,6 @@ func TestChangingMeta(t *testing.T) {
 		Name:         "test changing meta",
 		Notifier:     dummy,
 		NextSignal:   time.Duration(1) * time.Second,
-		AllClear:     false,
 		CallbackFunc: func(s *nanny.Signal) {},
 		Meta: map[string]string{
 			"ping": "original-message",
@@ -440,7 +429,6 @@ func TestChangingMeta(t *testing.T) {
 		Name:         "test changing meta",
 		Notifier:     dummy,
 		NextSignal:   time.Duration(1) * time.Second,
-		AllClear:     false,
 		CallbackFunc: func(s *nanny.Signal) {},
 		Meta: map[string]string{
 			"ping": "updated-message",
@@ -469,7 +457,6 @@ func TestGetTimers(t *testing.T) {
 		Name:         "test signal 1",
 		Notifier:     dummy,
 		NextSignal:   time.Duration(1) * time.Second,
-		AllClear:     false,
 		CallbackFunc: func(s *nanny.Signal) {},
 		Meta:         map[string]string{},
 	})
@@ -480,7 +467,6 @@ func TestGetTimers(t *testing.T) {
 		Name:         "test signal 2",
 		Notifier:     dummy,
 		NextSignal:   time.Duration(1) * time.Hour,
-		AllClear:     false,
 		CallbackFunc: func(s *nanny.Signal) {},
 		Meta:         map[string]string{},
 	})
@@ -565,7 +551,6 @@ func TestTimerMarshalJSONNextSignal(t *testing.T) {
 		Name:       signalName,
 		Notifier:   dummy,
 		NextSignal: dur,
-		AllClear:   false,
 	})
 	if err != nil {
 		t.Errorf("expected to handle signal without error, got error: %+v \n", err)
@@ -597,7 +582,6 @@ func TestTimerMarshalJSONNextSignal(t *testing.T) {
 		Name:       signalName,
 		Notifier:   dummy,
 		NextSignal: dur,
-		AllClear:   false,
 	})
 	if err != nil {
 		t.Errorf("expected to handle signal without error, got error: %+v \n", err)

--- a/pkg/nanny/timer.go
+++ b/pkg/nanny/timer.go
@@ -2,9 +2,11 @@ package nanny
 
 import (
 	"encoding/json"
-	"nanny/pkg/notifier"
+	"math"
 	"sync"
 	"time"
+
+	"nanny/pkg/notifier"
 
 	"github.com/pkg/errors"
 )
@@ -19,17 +21,19 @@ type Timer struct {
 	lock sync.Mutex
 }
 
-// MarshalJSON marshals a nanny.Timer into JSON. Fields name, notifier, next_signal and meta are exported
+// MarshalJSON marshals a nanny.Timer into JSON. Fields name, notifier, next_signal, all_clear and meta are exported
 func (nt *Timer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		Name       string            `json:"name"`
 		Notifier   string            `json:"notifier"`
 		NextSignal string            `json:"next_signal"`
+		AllClear   bool              `json:"all_clear"`
 		Meta       map[string]string `json:"meta,omitempty"`
 	}{
 		Name:       nt.signal.Name,
 		Notifier:   nt.signal.Notifier.String(),
 		NextSignal: nt.end.Format(time.RFC3339),
+		AllClear:   nt.signal.AllClear,
 		Meta:       nt.signal.Meta,
 	})
 }
@@ -37,23 +41,36 @@ func (nt *Timer) MarshalJSON() ([]byte, error) {
 func newTimer(s validSignal, nanny *Nanny) *Timer {
 	timer := &Timer{signal: s, nanny: nanny}
 	timer.end = time.Now().Add(timer.signal.NextSignal)
-	timer.timer = time.AfterFunc(timer.signal.NextSignal, timer.onExpire)
+	// If NextSignal is in the past but needed for all-clear notification do not notify user until Timer is reset
+	if timer.signal.NextSignal.Seconds() > 0 {
+		timer.timer = time.AfterFunc(timer.signal.NextSignal, timer.onExpire)
+	} else {
+		timer.timer = time.AfterFunc(math.MaxInt64, timer.onExpire)
+		timer.timer.Stop()
+	}
 	return timer
 }
 
 // Reset updates the nannyTimers signal to reset the timer
 func (nt *Timer) Reset(vs validSignal) {
 	nt.lock.Lock()
+	// Send all-clear notification if requested
+	if nt.signal.AllClear && time.Now().After(nt.end) {
+		nt.lock.Unlock()
+		nt.notify(true)
+		nt.lock.Lock()
+	}
 	defer nt.lock.Unlock()
 
 	nt.signal.NextSignal = vs.NextSignal
+	nt.signal.AllClear = vs.AllClear
 	nt.signal.Meta = vs.Meta
 	nt.end = time.Now().Add(vs.NextSignal)
 	nt.timer.Reset(vs.NextSignal)
 }
 
 func (nt *Timer) onExpire() {
-	err := nt.notify()
+	err := nt.notify(false)
 	if err != nil {
 		// Add context to the error message and call ErrorFunc.
 		err = errors.Wrapf(err, "error calling notifier: %T with signal: %+v", nt.signal.Notifier, nt.signal)
@@ -73,7 +90,7 @@ func (nt *Timer) onExpire() {
 	nt.lock.Unlock()
 }
 
-func (nt *Timer) notify() error {
+func (nt *Timer) notify(isAllClear bool) error {
 	nt.lock.Lock()
 	defer nt.lock.Unlock()
 	name := "Nanny"
@@ -85,6 +102,7 @@ func (nt *Timer) notify() error {
 		Nanny:      name,
 		Program:    nt.signal.Name,
 		NextSignal: nt.signal.NextSignal,
+		IsAllClear: isAllClear,
 		Meta:       nt.signal.Meta,
 	})
 }

--- a/pkg/notifier/email.go
+++ b/pkg/notifier/email.go
@@ -28,12 +28,23 @@ func (n *Email) Notify(msg Message) error {
 	m := gomail.NewMessage()
 	m.SetHeader("From", n.From)
 	m.SetHeader("To", n.To...)
-	if msg.IsAllClear {
-		m.SetHeader("Subject", fmt.Sprintf(n.SubjectAllClear, msg.Program))
-	} else {
-		m.SetHeader("Subject", fmt.Sprintf(n.Subject, msg.Program))
-	}
+	m.SetHeader("Subject", fmt.Sprintf(n.Subject, msg.Program))
 	m.SetBody("text/html", fmt.Sprintf(n.Body, fmt.Sprintf("%s (Meta: %v)", msg.Format(), msg.Meta)))
+
+	d := gomail.NewDialer(n.Server, n.Port, n.User, n.Password)
+
+	if err := d.DialAndSend(m); err != nil {
+		return errors.Wrap(err, "unable to notify via email")
+	}
+	return nil
+}
+
+func (n *Email) NotifyAllClear(msg Message) error {
+	m := gomail.NewMessage()
+	m.SetHeader("From", n.From)
+	m.SetHeader("To", n.To...)
+	m.SetHeader("Subject", fmt.Sprintf(n.SubjectAllClear, msg.Program))
+	m.SetBody("text/html", fmt.Sprintf(n.Body, fmt.Sprintf("%s (Meta: %v)", msg.FormatAllClear(), msg.Meta)))
 
 	d := gomail.NewDialer(n.Server, n.Port, n.User, n.Password)
 

--- a/pkg/notifier/email.go
+++ b/pkg/notifier/email.go
@@ -9,10 +9,11 @@ import (
 
 // Email implements Notifier interface for SMTP.
 type Email struct {
-	From    string
-	To      []string
-	Subject string
-	Body    string
+	From            string
+	To              []string
+	Subject         string
+	SubjectAllClear string
+	Body            string
 
 	Server   string
 	Port     int
@@ -27,7 +28,11 @@ func (n *Email) Notify(msg Message) error {
 	m := gomail.NewMessage()
 	m.SetHeader("From", n.From)
 	m.SetHeader("To", n.To...)
-	m.SetHeader("Subject", fmt.Sprintf(n.Subject, msg.Program))
+	if msg.IsAllClear {
+		m.SetHeader("Subject", fmt.Sprintf(n.SubjectAllClear, msg.Program))
+	} else {
+		m.SetHeader("Subject", fmt.Sprintf(n.Subject, msg.Program))
+	}
 	m.SetBody("text/html", fmt.Sprintf(n.Body, fmt.Sprintf("%s (Meta: %v)", msg.Format(), msg.Meta)))
 
 	d := gomail.NewDialer(n.Server, n.Port, n.User, n.Password)

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -8,6 +8,7 @@ import (
 // Notifier interface is used by Nanny to notify user on different outputs/services.
 type Notifier interface {
 	Notify(Message) error
+	NotifyAllClear(Message) error
 	String() string
 }
 
@@ -17,7 +18,6 @@ type Message struct {
 	Nanny      string        // Nanny's name
 	Program    string        // Program's name
 	NextSignal time.Duration // How long have we not heard from program.
-	IsAllClear bool          // Specify if this is an all-clear notification
 	Meta       map[string]string
 }
 
@@ -25,9 +25,9 @@ type Message struct {
 // This is intended for future use, mainly the ability to set message format from config
 // or from API.
 func (m *Message) Format() string {
-	if m.IsAllClear {
-		return fmt.Sprintf("%s: I did hear from \"%s\"!", m.Nanny, m.Program)
-	} else {
-		return fmt.Sprintf("%s: I did not hear from \"%s\" in %s!", m.Nanny, m.Program, m.NextSignal)
-	}
+	return fmt.Sprintf("%s: I did not hear from \"%s\" in %s!", m.Nanny, m.Program, m.NextSignal)
+}
+
+func (m *Message) FormatAllClear() string {
+	return fmt.Sprintf("%s: I did hear from \"%s\"!", m.Nanny, m.Program)
 }

--- a/pkg/notifier/notifier.go
+++ b/pkg/notifier/notifier.go
@@ -17,6 +17,7 @@ type Message struct {
 	Nanny      string        // Nanny's name
 	Program    string        // Program's name
 	NextSignal time.Duration // How long have we not heard from program.
+	IsAllClear bool          // Specify if this is an all-clear notification
 	Meta       map[string]string
 }
 
@@ -24,5 +25,9 @@ type Message struct {
 // This is intended for future use, mainly the ability to set message format from config
 // or from API.
 func (m *Message) Format() string {
-	return fmt.Sprintf("%s: I did not hear from \"%s\" in %s!", m.Nanny, m.Program, m.NextSignal)
+	if m.IsAllClear {
+		return fmt.Sprintf("%s: I did hear from \"%s\"!", m.Nanny, m.Program)
+	} else {
+		return fmt.Sprintf("%s: I did not hear from \"%s\" in %s!", m.Nanny, m.Program, m.NextSignal)
+	}
 }

--- a/pkg/notifier/sentry.go
+++ b/pkg/notifier/sentry.go
@@ -25,6 +25,13 @@ func (n *sentry) Notify(msg Message) error {
 	return nil
 }
 
+// NotifyAllClear implements Notifier interface for sentry.
+func (n *sentry) NotifyAllClear(msg Message) error {
+	// This may block since it is run in its own goroutine.
+	n.cli.CaptureMessageAndWait(msg.FormatAllClear(), msg.Meta)
+	return nil
+}
+
 func (n *sentry) String() string {
 	return "sentry"
 }

--- a/pkg/notifier/slack.go
+++ b/pkg/notifier/slack.go
@@ -54,6 +54,36 @@ func (s *slackNotifier) Notify(msg Message) error {
 	return nil
 }
 
+// NotifyAllClear implements Notifier interface for slack.
+func (s *slackNotifier) NotifyAllClear(msg Message) error {
+	msgText := msg.FormatAllClear()
+	hexGreen := "#00FF00"
+	attachment := slack.Attachment{
+		Fallback: &msgText,
+		Text:     &msgText,
+		Color:    &hexGreen,
+	}
+	if len(msg.Meta) != 0 {
+		for key, value := range msg.Meta {
+			attachment.AddField(slack.Field{Title: key, Value: value})
+		}
+	}
+	payload := slack.Payload{
+		Username:    "Nanny",
+		IconEmoji:   ":baby_chick:",
+		Attachments: []slack.Attachment{attachment},
+	}
+	errs := slack.Send(s.webhookURL, "", payload)
+	if len(errs) > 0 {
+		errStr := ""
+		for _, err := range errs {
+			errStr = fmt.Sprintf("%s, ", err)
+		}
+		return errors.New(errStr)
+	}
+	return nil
+}
+
 func (s *slackNotifier) String() string {
 	return "slack"
 }

--- a/pkg/notifier/stderr.go
+++ b/pkg/notifier/stderr.go
@@ -18,6 +18,13 @@ func (n *StdErr) Notify(msg Message) error {
 	return errors.Wrap(err, "unable to notify via stderr")
 }
 
+// NotifyAllClear to stderr.
+func (n *StdErr) NotifyAllClear(msg Message) error {
+	text := fmt.Sprintf("%s: %s (Meta: %v)\n", time.Now().Format(time.RFC3339), msg.FormatAllClear(), msg.Meta)
+	_, err := os.Stderr.WriteString(text)
+	return errors.Wrap(err, "unable to notify via stderr")
+}
+
 // MarshalJSON marshals the stderr notifier into a "stderr" string
 func (n *StdErr) String() string {
 	return "stderr"

--- a/pkg/notifier/twilio.go
+++ b/pkg/notifier/twilio.go
@@ -22,8 +22,29 @@ func NewTwilio(accountSid, authToken, appSid, from, to string) Notifier {
 	}
 }
 
+// Notify implements Notifier interface for twilio.
 func (n *twilio) Notify(msg Message) error {
 	resp, exc, err := n.t.SendSMS(n.from, n.to, msg.Format(), "", n.appSid)
+	if err != nil {
+		return errors.Wrap(err, "unable to send SMS via twilio")
+	}
+	if exc != nil {
+		return errors.Errorf("error while sending SMS via twilio: %+v", exc)
+	}
+	// I know it does not make sense that resp would be nil, but since the type
+	// is *gotwilio.SmsResponse we should check.
+	if resp == nil {
+		return errors.Errorf("*gotwilio.SmsResponse is nil, WUT?")
+	}
+	if resp.Status == "undelivered" || resp.Status == "failed" {
+		return errors.Errorf("unable to send SMS via twilio: %+v", resp)
+	}
+	return nil
+}
+
+// NotifyAllClear implements Notifier interface for twilio.
+func (n *twilio) NotifyAllClear(msg Message) error {
+	resp, exc, err := n.t.SendSMS(n.from, n.to, msg.FormatAllClear(), "", n.appSid)
 	if err != nil {
 		return errors.Wrap(err, "unable to send SMS via twilio")
 	}

--- a/pkg/notifier/xmpp.go
+++ b/pkg/notifier/xmpp.go
@@ -76,6 +76,34 @@ func (x *xmppNotifier) Notify(msg Message) error {
 	return nil
 }
 
+// NotifyAllClear implements the Notifier interface for xmpp.
+func (x *xmppNotifier) NotifyAllClear(msg Message) error {
+	options := xmpp.Options{
+		Host:     x.Server + ":" + strconv.Itoa(x.Port),
+		User:     x.User,
+		Password: x.Password,
+		Resource: x.Resource,
+		NoTLS:    x.NoTLS,
+	}
+
+	client, err := options.NewClient()
+	if err != nil {
+		return errors.Wrap(err, "unable to connect to xmpp server")
+	}
+
+	for _, remoteAddress := range x.To {
+		_, err = client.Send(xmpp.Chat{
+			Remote: remoteAddress,
+			Text:   fmt.Sprintf("%s (Meta: %v)", msg.FormatAllClear(), msg.Meta),
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to notify via xmpp")
+		}
+	}
+
+	return nil
+}
+
 func (x *xmppNotifier) String() string {
 	return "xmpp"
 }

--- a/pkg/storage/sqlite.go
+++ b/pkg/storage/sqlite.go
@@ -41,13 +41,13 @@ func (d *sqliteDB) Load() ([]Signal, error) {
 }
 
 func (d *sqliteDB) Save(s Signal) error {
-	sql := "INSERT OR REPLACE INTO `signal` (name, notifier, next_signal, meta) VALUES (?, ?, ?, ?)"
+	sql := "INSERT OR REPLACE INTO `signal` (name, notifier, next_signal, all_clear, meta) VALUES (?, ?, ?, ?, ?)"
 
 	meta, err := json.Marshal(s.Meta)
 	if err != nil {
 		return errors.Wrap(err, "unable to jsonify signal metadata")
 	}
-	_, err = d.db.Exec(sql, s.Name, s.Notifier, s.NextSignal.UTC(), meta)
+	_, err = d.db.Exec(sql, s.Name, s.Notifier, s.NextSignal.UTC(), s.AllClear, meta)
 	if err != nil {
 		return errors.Wrapf(err, "unable to save signal to sqlite: %+v", s)
 	}

--- a/pkg/storage/sqlite_test.go
+++ b/pkg/storage/sqlite_test.go
@@ -27,7 +27,6 @@ func TestSQLiteDataConsistency(t *testing.T) {
 	signal := storage.Signal{
 		Name:       "test",
 		NextSignal: time.Now(),
-		AllClear:   false,
 		Notifier:   "stderr",
 		Meta:       map[string]string{"meta": "data"},
 	}

--- a/pkg/storage/sqlite_test.go
+++ b/pkg/storage/sqlite_test.go
@@ -27,6 +27,7 @@ func TestSQLiteDataConsistency(t *testing.T) {
 	signal := storage.Signal{
 		Name:       "test",
 		NextSignal: time.Now(),
+		AllClear:   false,
 		Notifier:   "stderr",
 		Meta:       map[string]string{"meta": "data"},
 	}
@@ -56,6 +57,10 @@ func compareSignals(t *testing.T, this storage.Signal, other storage.Signal) {
 	// See: https://golang.org/pkg/time/#hdr-Monotonic_Clocks
 	if this.NextSignal.Round(0) != other.NextSignal {
 		t.Errorf("saved signal is not equal to loaded signal, saved: %+v, loaded: %+v", this.NextSignal, other.NextSignal)
+	}
+
+	if this.AllClear != other.AllClear {
+		t.Errorf("saved signal is not equal to loaded signal, saved: %+v, loaded: %+v", this.AllClear, other.AllClear)
 	}
 
 	if this.Notifier != other.Notifier {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -19,5 +19,6 @@ type Signal struct {
 	Name       string `xorm:"pk"`
 	Notifier   string
 	NextSignal time.Time
+	AllClear   bool `xorm:"default 0"`
 	Meta       map[string]string
 }


### PR DESCRIPTION
This pull request adds the possibility to activate all-clear notifications that are sent when a call is received after an alert has been sent.

When some time passes between an alert being sent and you seeing the alert e.g. in your inbox it is not clear if the problem has been resolved in the meantime without checking the service itself or the nanny signals page. All-clear notifications solve this problem.
